### PR TITLE
Pag pie tweak

### DIFF
--- a/HLTDatasets.h
+++ b/HLTDatasets.h
@@ -92,8 +92,11 @@ public:
     : name              (datasetName)
     , isNewTrigger      (isNewTrigger)
     , numEventsPassed   (0)
+    , numWeightedEventsPassed(0) 
     , rate              (0)
     , rateUncertainty2  (0)
+    , weightedRate              (0)
+    , weightedRateUncertainty2  (0)
   { }
   /**
     Sets up storage for this dataset, given the list of datasets in the scenario.


### PR DESCRIPTION
Allowing to use the same triggername in different datasets, keeping the same index of the triggerbit. This is the way to go for PAGPIES but several instances of the path with different prescales should also be available in the ntuple if preparing for datasets. So a warning is issued.... just in case